### PR TITLE
chore: fix BTC regex

### DIFF
--- a/lib/fushin/posts/post.rb
+++ b/lib/fushin/posts/post.rb
@@ -29,7 +29,7 @@ module Fushin
       end
 
       def btcs
-        @btcs ||= main.text.scan(/[13][a-km-zA-HJ-NP-Z0-9]{26,33}/).uniq.map do |address|
+        @btcs ||= main.text.scan(/\b[13][a-km-zA-HJ-NP-Z0-9]{26,33}\b/).uniq.map do |address|
           Models::BTC.new(address)
         end
       end


### PR DESCRIPTION
add \b to the start & end of the regex for preventing mismatching